### PR TITLE
Modify to only use the new Benhar spectral functions for heavy nuclei

### DIFF
--- a/dbase.f
+++ b/dbase.f
@@ -502,7 +502,7 @@ C DJG:
      >		spec%p%P, Mh2, Ebeam, spec%e%P)
 
 ! ... Read in the theory file (for A(e,e'p))
-	if (doing_deuterium .or. doing_heavy) then
+	if (doing_deuterium .or. (doing_heavy.and.(.not.use_benhar_sf))) then
 	  call theory_init(success)
 	  if (.not.success) stop 'THEORY_INIT failed!'
 	endif
@@ -541,7 +541,7 @@ C DJG:
 ! ... Em_max,Pm_max.
 !      Also load spectral function for deuterium of heavy so we have the choice later
 !      to use it for (e,e'p)
-	if(doing_hepi.or.doing_hekaon .or. (doing_deuterium.or.doing_heavy)) then
+	if(doing_hepi.or.doing_hekaon .or. (doing_heavy.and.use_benhar_sf)) then
 	  if (nint(targ%A).eq.3) then
 	    write(6,*) 'Using the mod version of 3He S.F. rather than Paris.'
 	    tmpfile='benharsf_3mod.dat'

--- a/event.f
+++ b/event.f
@@ -1331,10 +1331,10 @@ CDJG Calculate the "Collins" (phi_pq+phi_targ) and "Sivers"(phi_pq-phi_targ) ang
 
 	if (doing_hyd_elast.or.doing_pion.or.doing_kaon.or.doing_delta.or.doing_phsp.or.doing_rho.or.doing_semi) then !no SF.
 	  main%SF_weight=1.0
-	else if (use_benhar_sf) then ! Doing Spectral Functions
+	else if (use_benhar_sf.and.doing_heavy) then ! Doing Spectral Functions
 	   call sf_lookup_diff(vertex%Em, vertex%Pm, weight)
 	   main%SF_weight = targ%Z*transparency*weight
- 	else if (doing_deuterium .or. doing_heavy) then
+ 	else if (doing_deuterium .or. (doing_heavy.and.(.not.use_benhar_sf))) then
 	  main%SF_weight = 0.0
 	  do i=1,nrhoPm
 	    weight = 0.0


### PR DESCRIPTION
Had been setup to try and use Benhar for D(eep) but there was no Benhar deuteron model
